### PR TITLE
fix: 在多卡选择会话中处理查卡命令

### DIFF
--- a/nonebot_plugin_ocgbot_v2/ocg.py
+++ b/nonebot_plugin_ocgbot_v2/ocg.py
@@ -35,7 +35,7 @@ search_card = on_command("查卡", aliases={"ck", "CK"})
 
 
 @search_card.handle()
-async def _(bot: Bot, event: Event, state: T_State, args: Message = CommandArg()):
+async def _searchCardHandler(bot: Bot, event: Event, state: T_State, args: Message = CommandArg()):
     if isinstance(event, PrivateMessageEvent):
         sessionId = 'user_' + str(event.user_id)
     if isinstance(event, GroupMessageEvent):
@@ -113,6 +113,9 @@ async def _(bot: Bot, event: Event, state: T_State):
                 state['page'] = page
                 flag = 1
         else:
+            isCommand = await search_card.rule(bot,event,state)    # 收到新的查卡命令
+            if isCommand:
+                await _searchCardHandler(bot,event,state,CommandArg().dependency(state))    # 转回查卡处理函数
             await search_card.finish()
         if flag is not None:
             js = getCard(name, str(page))


### PR DESCRIPTION
在实际运行中经常遇到用户在查卡结果为多张卡时不回复数字选卡而是直接重新发送新的查卡命令，而此条命令会被无视，导致不好的用户体验。